### PR TITLE
pass classnames and styles through to the preview image

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wordsby-components",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Components for wordsby",
   "main": "index.js",
   "author": "Tyler Barnes <tyler@known.design>",

--- a/src/components/img.js
+++ b/src/components/img.js
@@ -39,10 +39,13 @@ class Wimg extends Component {
 
     if (useStringUrl || useNestedStringUrl) {
       const stringUrl = useStringUrl ? field : field.url;
-      const { style } = this.props;
+      const { style, className } = this.props;
+
       return (
         <div
-          className="gatsby-image-wrapper wordsby-image-preview"
+          className={`gatsby-image-wrapper wordsby-image-preview ${
+            className ? className : ""
+          }`}
           style={{ position: "relative", overflow: "hidden", ...style }}
         >
           <div
@@ -66,7 +69,6 @@ class Wimg extends Component {
               transition: "opacity 0.5s ease 0s"
             }}
             src={stringUrl}
-            {...props}
           />
         </div>
       );


### PR DESCRIPTION
This makes gatsby-image and wordsby preview images look identical